### PR TITLE
short circuit sequence on sdk error

### DIFF
--- a/cloudfront-sg.js
+++ b/cloudfront-sg.js
@@ -112,7 +112,7 @@ Seq()
         };
         EC2.describeSecurityGroups(params, function (err, data) {
             if (err) {
-                _self(err);
+                return _self(err);
             }
             for (var j in data.SecurityGroups) {
                 var securityGroup = data.SecurityGroups[j];


### PR DESCRIPTION
an error returned by the node aws sdk almost certainly means there is no resp data to traverse. returning here will prevent the script from continuing after receiving an api error.
